### PR TITLE
Add Radiotap support and improve Wireshark streaming

### DIFF
--- a/Radiotap.h
+++ b/Radiotap.h
@@ -1,0 +1,166 @@
+#ifndef RADIOTAP_H
+#define RADIOTAP_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifndef STRUCT_PACKED
+#define STRUCT_PACKED __attribute__((packed))
+#endif
+
+/*
+  Radiotap fields are stored little-endian and must appear in increasing present
+  bit order. Each field is aligned relative to the start of the radiotap header,
+  not relative to the surrounding PCAP record.
+
+  The first WiFiPcap pass intentionally uses only metadata the ESP32
+  promiscuous RX callback exposes directly and reliably: flags, legacy rate,
+  channel, RSSI, noise floor, and antenna.
+
+  References:
+    https://www.radiotap.org/
+    Linux: include/net/ieee80211_radiotap.h
+*/
+
+constexpr uint8_t RADIOTAP_VERSION = 0;
+
+enum RadiotapPresentBit : uint8_t {
+    RADIOTAP_PRESENT_TSFT           = 0,
+    RADIOTAP_PRESENT_FLAGS          = 1,
+    RADIOTAP_PRESENT_RATE           = 2,
+    RADIOTAP_PRESENT_CHANNEL        = 3,
+    RADIOTAP_PRESENT_FHSS           = 4,
+    RADIOTAP_PRESENT_DBM_ANTSIGNAL  = 5,
+    RADIOTAP_PRESENT_DBM_ANTNOISE   = 6,
+    RADIOTAP_PRESENT_LOCK_QUALITY   = 7,
+    RADIOTAP_PRESENT_TX_ATTENUATION = 8,
+    RADIOTAP_PRESENT_DB_TX_ATTENUATION = 9,
+    RADIOTAP_PRESENT_DBM_TX_POWER   = 10,
+    RADIOTAP_PRESENT_ANTENNA        = 11,
+    RADIOTAP_PRESENT_DB_ANTSIGNAL   = 12,
+    RADIOTAP_PRESENT_DB_ANTNOISE    = 13,
+    RADIOTAP_PRESENT_RX_FLAGS       = 14,
+    RADIOTAP_PRESENT_MCS            = 19,
+    RADIOTAP_PRESENT_AMPDU_STATUS   = 20,
+    RADIOTAP_PRESENT_VHT            = 21,
+    RADIOTAP_PRESENT_TIMESTAMP      = 22,
+    RADIOTAP_PRESENT_EXT            = 31
+};
+
+constexpr uint32_t radiotap_present_bit(RadiotapPresentBit bit) {
+    return (1UL << bit);
+}
+
+enum RadiotapFlags : uint8_t {
+    RADIOTAP_F_CFP       = 0x01,
+    RADIOTAP_F_SHORTPRE  = 0x02,
+    RADIOTAP_F_WEP       = 0x04,
+    RADIOTAP_F_FRAG      = 0x08,
+    RADIOTAP_F_FCS       = 0x10,
+    RADIOTAP_F_DATAPAD   = 0x20,
+    RADIOTAP_F_BADFCS    = 0x40,
+    RADIOTAP_F_SHORTGI   = 0x80
+};
+
+enum RadiotapChannelFlags : uint16_t {
+    RADIOTAP_CHAN_TURBO  = 0x0010,
+    RADIOTAP_CHAN_CCK    = 0x0020,
+    RADIOTAP_CHAN_OFDM   = 0x0040,
+    RADIOTAP_CHAN_2GHZ   = 0x0080,
+    RADIOTAP_CHAN_5GHZ   = 0x0100,
+    RADIOTAP_CHAN_PASSIVE = 0x0200,
+    RADIOTAP_CHAN_DYN    = 0x0400,
+    RADIOTAP_CHAN_GFSK   = 0x0800,
+    RADIOTAP_CHAN_GSM    = 0x1000,
+    RADIOTAP_CHAN_STURBO = 0x2000,
+    RADIOTAP_CHAN_HALF   = 0x4000,
+    RADIOTAP_CHAN_QUARTER = 0x8000
+};
+
+enum RadiotapRxFlags : uint16_t {
+    RADIOTAP_RX_F_BADPLCP = 0x0002
+};
+
+enum RadiotapMcsHave : uint8_t {
+    RADIOTAP_MCS_HAVE_BW   = 0x01,
+    RADIOTAP_MCS_HAVE_MCS  = 0x02,
+    RADIOTAP_MCS_HAVE_GI   = 0x04,
+    RADIOTAP_MCS_HAVE_FMT  = 0x08,
+    RADIOTAP_MCS_HAVE_FEC  = 0x10,
+    RADIOTAP_MCS_HAVE_STBC = 0x20
+};
+
+enum RadiotapMcsFlags : uint8_t {
+    RADIOTAP_MCS_BW_20      = 0x00,
+    RADIOTAP_MCS_BW_40      = 0x01,
+    RADIOTAP_MCS_BW_20L     = 0x02,
+    RADIOTAP_MCS_BW_20U     = 0x03,
+    RADIOTAP_MCS_SGI        = 0x04,
+    RADIOTAP_MCS_FMT_GF     = 0x08,
+    RADIOTAP_MCS_FEC_LDPC   = 0x10,
+    RADIOTAP_MCS_STBC_SHIFT = 5
+};
+
+struct RadiotapHeader {
+    uint8_t version;
+    uint8_t pad;
+    uint16_t length;
+    uint32_t present;
+} STRUCT_PACKED;
+
+struct RadiotapChannel {
+    uint16_t frequency;
+    uint16_t flags;
+} STRUCT_PACKED;
+
+struct RadiotapMcs {
+    uint8_t known;
+    uint8_t flags;
+    uint8_t index;
+} STRUCT_PACKED;
+
+/*
+  Fixed first-pass header layout:
+    RadiotapHeader        offset 0,  size 8
+    flags                 offset 8,  size 1
+    rate                  offset 9,  size 1, 500 kb/s units
+    channel               offset 10, size 4, 2-byte aligned
+    dbm_antsignal         offset 14, size 1
+    dbm_antnoise          offset 15, size 1
+    antenna               offset 16, size 1
+
+  No padding is required for this field set.
+*/
+struct RadiotapHeaderBasic {
+    RadiotapHeader hdr;
+    uint8_t flags;
+    uint8_t rate;
+    RadiotapChannel channel;
+    int8_t dbm_antsignal;
+    int8_t dbm_antnoise;
+    uint8_t antenna;
+} STRUCT_PACKED;
+
+constexpr uint32_t RADIOTAP_BASIC_PRESENT =
+    radiotap_present_bit(RADIOTAP_PRESENT_FLAGS) |
+    radiotap_present_bit(RADIOTAP_PRESENT_RATE) |
+    radiotap_present_bit(RADIOTAP_PRESENT_CHANNEL) |
+    radiotap_present_bit(RADIOTAP_PRESENT_DBM_ANTSIGNAL) |
+    radiotap_present_bit(RADIOTAP_PRESENT_DBM_ANTNOISE) |
+    radiotap_present_bit(RADIOTAP_PRESENT_ANTENNA);
+
+constexpr uint16_t RADIOTAP_BASIC_LENGTH = sizeof(RadiotapHeaderBasic);
+
+static_assert(8u == sizeof(RadiotapHeader), "RadiotapHeader layout changed");
+static_assert(10u == offsetof(RadiotapHeaderBasic, channel), "Radiotap channel alignment changed");
+static_assert(17u == sizeof(RadiotapHeaderBasic), "RadiotapHeaderBasic layout changed");
+
+constexpr uint16_t radiotap_channel_frequency_2ghz(uint8_t channel) {
+    return (14 == channel) ? 2484u : (2407u + (uint16_t)channel * 5u);
+}
+
+constexpr uint16_t radiotap_channel_flags_2ghz(bool legacy_rate_cck) {
+    return RADIOTAP_CHAN_2GHZ | (legacy_rate_cck ? RADIOTAP_CHAN_CCK : RADIOTAP_CHAN_OFDM);
+}
+
+#endif

--- a/SerialPcap.cpp
+++ b/SerialPcap.cpp
@@ -30,6 +30,9 @@
 #include <esp_wifi.h>
 // #include <hal/usb_serial_jtag_ll.h>
 #include "SerialPcap.h"
+// Added for synthetic Radiotap headers that carry ESP32 RX metadata, such as
+// RSSI, before each 802.11 frame in the PCAP stream.
+#include "Radiotap.h"
 #include "WiFiPcap.h"
 #include "Interlocks.h"
 
@@ -37,7 +40,15 @@
 #define USE_WIFIPCAP_FILTER_AP_SESSION 0
 #endif
 
-#if ! ARDUINO_USB_CDC_ON_BOOT && ! ARDUINO_USB_MODE
+// #if ! ARDUINO_USB_CDC_ON_BOOT && ! ARDUINO_USB_MODE
+// USBCDC USBSerial(0);
+// #endif
+
+// When USB CDC is not provided by Serial-on-boot, create the matching global
+// USBSerial object for the selected Arduino USB backend.
+#if ! ARDUINO_USB_CDC_ON_BOOT && ARDUINO_USB_MODE
+HWCDC USBSerial;
+#elif ! ARDUINO_USB_CDC_ON_BOOT && ! ARDUINO_USB_MODE
 USBCDC USBSerial(0);
 #endif
 
@@ -91,7 +102,10 @@ struct SerialTask {
     TaskState volatile state;
     uint32_t channel = 0;
     SERIAL_INF* volatile pcapSerial = NULL;
-    TaskHandle_t volatile task = NULL;
+    // TaskHandle_t volatile task = NULL;
+    // FreeRTOS task creation writes the handle through TaskHandle_t *; keep the
+    // handle itself non-volatile so it can be passed without a type cast.
+    TaskHandle_t task = NULL;
     QueueHandle_t volatile work_queue = NULL;
 
     // Track time rollover, takes ~1.193046 hours
@@ -348,12 +362,29 @@ static bool isTxHang(SerialTask *session) {
 static inline bool isTxHang(SerialTask *session) { return false; }
 #endif
 
+// HWCDC does not provide a reliable DTR disconnect indication. The host script
+// sends EOT when closing, so poll RX while streaming and treat it as DTR LOW.
+static bool checkRxAbort(SerialTask *session) {
+    while (0 < session->pcapSerial->available()) {
+        if ('\x04' == session->pcapSerial->read()) {
+            ESP_LOGE(TAG, "Write PCAP RX EOT - Abort!");
+            serial_pcap_notifyDtrRts(false, false);
+            return true;
+        }
+    }
+    return false;
+}
+
 bool writeWait(SerialTask *session, const void *data, const size_t total_length) {
     static bool nodelay = true;
     const uint8_t *pb = (const uint8_t *)data;
     ssize_t remaining = total_length;
     ssize_t wrote = 0;
     while (remaining) {
+        // Check for host EOT before each write attempt so a clean shutdown is
+        // noticed even while USB TX continues to make progress.
+        if (checkRxAbort(session)) return false;
+
         wrote = session->pcapSerial->write(pb, remaining);
         if (0 <= wrote) {
             remaining -= wrote;
@@ -368,13 +399,17 @@ bool writeWait(SerialTask *session, const void *data, const size_t total_length)
                 nodelay = false;
 #if 1 //ARDUINO_USB_MODE
                 if (isTxHang(session)) return false;
-                // HWCDC does not support DTR so we rely on the script send an
-                // EOT when closing serial. On EOT, simulate a DTR LOW event.
-                if ('\x04' == session->pcapSerial->read()) {
-                    ESP_LOGE(TAG, "Write PCAP RX EOT - Abort!");
-                    serial_pcap_notifyDtrRts(false, false);
-                    return false;
-                }
+
+                // EOT handling moved to checkRxAbort() at the top of the write
+                // loop so host shutdown is detected even when writes keep succeeding.
+
+                // // HWCDC does not support DTR so we rely on the script send an
+                // // EOT when closing serial. On EOT, simulate a DTR LOW event.
+                // if ('\x04' == session->pcapSerial->read()) {
+                //     ESP_LOGE(TAG, "Write PCAP RX EOT - Abort!");
+                //     serial_pcap_notifyDtrRts(false, false);
+                //     return false;
+                // }
 #endif
             } else {
                 nodelay = true;
@@ -415,7 +450,15 @@ bool writePcapWait(SerialTask *session, const WiFiPcap *wpcap) {
 const uint8_t k_llc_snap_hdr[] = { 0xAAu, 0xAAu, 0x03u, 0x00, 0x00, 0x00 };
 
 static void cache_authenticate(WiFiPcap *wpcap) {
-    const WiFiPktHdr* const pkt = (WiFiPktHdr*)wpcap->payload;
+    // Original:
+    // const WiFiPktHdr* const pkt = (WiFiPktHdr*)wpcap->payload;
+    //
+    // PCAP payload now starts with Radiotap, so skip that header before
+    // inspecting the 802.11 frame for authentication packets.
+    const RadiotapHeader * const rtap = (RadiotapHeader*)wpcap->payload;
+    const size_t dot11_offset = rtap->length;
+    if (wpcap->pcap_header.capture_length <= dot11_offset) return;
+    const WiFiPktHdr* const pkt = (WiFiPktHdr*)&wpcap->payload[dot11_offset];
     if (0 == cust_fltr.cache_auth) return;
     // Rapid disqualifier
     size_t len = offsetof(struct WiFiPktHdr, addr4);
@@ -424,7 +467,12 @@ static void cache_authenticate(WiFiPcap *wpcap) {
         WLAN_FC_STYPE_QOS_DATA == pkt->fctl.subtype) qos_len = sizeof(QOS_CNTRL);
 
     len += sizeof(LLC) + qos_len;
-    if (wpcap->pcap_header.capture_length <= len) return;
+    // Original:
+    // if (wpcap->pcap_header.capture_length <= len) return;
+    //
+    // capture_length includes Radiotap, but len is measured inside the 802.11
+    // frame. Include the Radiotap offset when validating packet bounds.
+    if (wpcap->pcap_header.capture_length <= (dot11_offset + len)) return;
 
     const LLC * const llc = (LLC*)((uintptr_t)pkt->addr4.mac + qos_len);
     if (k_802_1x_authentication != llc->type) return;
@@ -557,6 +605,16 @@ esp_err_t pcap_serial_start(SerialTask *session, pcap_link_type_t link_type) {
 
     begin_promiscuous(channel, filter, filter);
 
+    // Original:
+    // .snaplen = PCAP_MAX_CAPTURE_PACKET_SIZE,  // MAX length of captured packets, in octets
+    //
+    // Radiotap packets include metadata before the 802.11 frame, so the file
+    // snaplen must include those extra bytes when using the Radiotap link type.
+    const uint32_t snaplen =
+        (PCAP_LINK_TYPE_IEEE802_11_RADIOTAP == link_type)
+        ? (PCAP_MAX_CAPTURE_PACKET_SIZE + RADIOTAP_BASIC_LENGTH)
+        : PCAP_MAX_CAPTURE_PACKET_SIZE;
+
     // Write Pcap File header - About PCAP_MAGIC, The decoder will use it to
     // detect if byte swapping is needed when interpreting the results. No need
     // for extra care in constructing byteswapped headers.
@@ -566,7 +624,7 @@ esp_err_t pcap_serial_start(SerialTask *session, pcap_link_type_t link_type) {
         .minor = PCAP_DEFAULT_VERSION_MINOR,      //
         .zone  = PCAP_DEFAULT_TIME_ZONE_GMT,      // Most implementations set tp 0
         .sigfigs = 0,                             // accuracy of timestamps, ditto above
-        .snaplen = PCAP_MAX_CAPTURE_PACKET_SIZE,  // MAX length of captured packets, in octets
+        .snaplen = snaplen,                       // MAX length of captured packets, in octets
         .link_type = link_type
     };
 
@@ -709,7 +767,12 @@ static void serial_task(void *parameters) {
                 free(wpcap);
                 wpcap = NULL;
             }
-            need_resync = (ESP_OK != pcap_serial_start(session, PCAP_LINK_TYPE_802_11));
+            // Original:
+            // need_resync = (ESP_OK != pcap_serial_start(session, PCAP_LINK_TYPE_802_11));
+            //
+            // The payload now starts with a Radiotap header before Dot11 bytes,
+            // so advertise the Radiotap link type in the PCAP file header.
+            need_resync = (ESP_OK != pcap_serial_start(session, PCAP_LINK_TYPE_IEEE802_11_RADIOTAP));
             // Clear queue so we can get time synced properly with host
             while (pdTRUE == xQueueReceive(session->work_queue, &wpcap, 0)) {
                 cache_authenticate(wpcap);
@@ -795,6 +858,86 @@ static void serial_task(void *parameters) {
 //
 #pragma GCC push_options
 #pragma GCC optimize("Ofast")
+
+// Radiotap's Rate field is in 500 kb/s units. ESP32 only marks rx_ctrl.rate
+// valid for non-HT 11b/g packets, so return 0 when an MCS-specific Radiotap
+// field would be needed instead.
+static uint8_t radiotap_rate_500kbps(const wifi_pkt_rx_ctrl_t *rx_ctrl) {
+    if (0 != rx_ctrl->sig_mode) return 0;
+
+    switch (rx_ctrl->rate) {
+        case WIFI_PHY_RATE_1M_L:  return 2u;
+        case WIFI_PHY_RATE_2M_L:
+        case WIFI_PHY_RATE_2M_S:  return 4u;
+        case WIFI_PHY_RATE_5M_L:
+        case WIFI_PHY_RATE_5M_S:  return 11u;
+        case WIFI_PHY_RATE_11M_L:
+        case WIFI_PHY_RATE_11M_S: return 22u;
+        case WIFI_PHY_RATE_6M:    return 12u;
+        case WIFI_PHY_RATE_9M:    return 18u;
+        case WIFI_PHY_RATE_12M:   return 24u;
+        case WIFI_PHY_RATE_18M:   return 36u;
+        case WIFI_PHY_RATE_24M:   return 48u;
+        case WIFI_PHY_RATE_36M:   return 72u;
+        case WIFI_PHY_RATE_48M:   return 96u;
+        case WIFI_PHY_RATE_54M:   return 108u;
+        default:                  return 0u;
+    }
+}
+
+// Channel flags need to distinguish 2.4 GHz CCK rates from OFDM rates. HT
+// packets are left as OFDM-like for now until an MCS Radiotap field is emitted.
+static bool radiotap_is_cck_rate(const wifi_pkt_rx_ctrl_t *rx_ctrl) {
+    if (0 != rx_ctrl->sig_mode) return false;
+
+    switch (rx_ctrl->rate) {
+        case WIFI_PHY_RATE_1M_L:
+        case WIFI_PHY_RATE_2M_L:
+        case WIFI_PHY_RATE_2M_S:
+        case WIFI_PHY_RATE_5M_L:
+        case WIFI_PHY_RATE_5M_S:
+        case WIFI_PHY_RATE_11M_L:
+        case WIFI_PHY_RATE_11M_S:
+            return true;
+        default:
+            return false;
+    }
+}
+
+static uint8_t radiotap_packet_flags(const wifi_pkt_rx_ctrl_t *rx_ctrl, bool include_fcs) {
+    uint8_t flags = include_fcs ? RADIOTAP_F_FCS : 0u;
+
+    // Short preamble only applies to the legacy 2/5.5/11 Mbps CCK encodings.
+    if (0 == rx_ctrl->sig_mode) {
+        switch (rx_ctrl->rate) {
+            case WIFI_PHY_RATE_2M_S:
+            case WIFI_PHY_RATE_5M_S:
+            case WIFI_PHY_RATE_11M_S:
+                flags |= RADIOTAP_F_SHORTPRE;
+                break;
+            default:
+                break;
+        }
+    }
+    return flags;
+}
+
+static void fillRadiotapHeader(RadiotapHeaderBasic *rtap, const wifi_pkt_rx_ctrl_t *rx_ctrl, bool include_fcs) {
+    // Build the fixed first-pass Radiotap header immediately before copying the
+    // 802.11 bytes, making the packet parse as RadioTap / Dot11 in readers.
+    rtap->hdr.version = RADIOTAP_VERSION;
+    rtap->hdr.pad = 0;
+    rtap->hdr.length = RADIOTAP_BASIC_LENGTH;
+    rtap->hdr.present = RADIOTAP_BASIC_PRESENT;
+    rtap->flags = radiotap_packet_flags(rx_ctrl, include_fcs);
+    rtap->rate = radiotap_rate_500kbps(rx_ctrl);
+    rtap->channel.frequency = radiotap_channel_frequency_2ghz(rx_ctrl->channel);
+    rtap->channel.flags = radiotap_channel_flags_2ghz(radiotap_is_cck_rate(rx_ctrl));
+    rtap->dbm_antsignal = rx_ctrl->rssi;
+    rtap->dbm_antnoise = rx_ctrl->noise_floor;
+    rtap->antenna = rx_ctrl->ant;
+}
+
 esp_err_t serial_pcap_cb(void *recv_buf, wifi_promiscuous_pkt_type_t type) {
     wifi_promiscuous_pkt_t *snoop = (wifi_promiscuous_pkt_t *)recv_buf;
     SerialTask *session = &st;
@@ -893,10 +1036,23 @@ esp_err_t serial_pcap_cb(void *recv_buf, wifi_promiscuous_pkt_type_t type) {
         if (keepLength > 0) {
             // This may need to use PSRAM
             // Use work_queue size as a limiter on total memory allocated.wpcap->payload / 1000000u;
-            WiFiPcap *wpcap = (WiFiPcap*)malloc(keepLength + sizeof(WiFiPcap));
+            // Original:
+            // WiFiPcap *wpcap = (WiFiPcap*)malloc(keepLength + sizeof(WiFiPcap));
+            //
+            // Allocate room for the synthetic Radiotap header plus the captured
+            // 802.11 frame bytes.
+            const size_t dot11CaptureLength = (size_t)keepLength;
+            const size_t dot11PacketLength = (size_t)length;
+            const size_t pcapPayloadLength = RADIOTAP_BASIC_LENGTH + dot11CaptureLength;
+            WiFiPcap *wpcap = (WiFiPcap*)malloc(pcapPayloadLength + sizeof(WiFiPcap));
             if (wpcap) {
-                // Make a copy of received packet
-                memcpy(wpcap->payload, snoop->payload, keepLength);
+                // Original:
+                // memcpy(wpcap->payload, snoop->payload, keepLength);
+                //
+                // Prepend Radiotap metadata from rx_ctrl, then copy the original
+                // 802.11 frame immediately after it.
+                fillRadiotapHeader((RadiotapHeaderBasic*)wpcap->payload, &snoop->rx_ctrl, cust_fltr.fcslen);
+                memcpy(&wpcap->payload[RADIOTAP_BASIC_LENGTH], snoop->payload, dot11CaptureLength);
                 /*
                   Prepare pcap packet header
                 */
@@ -904,8 +1060,14 @@ esp_err_t serial_pcap_cb(void *recv_buf, wifi_promiscuous_pkt_type_t type) {
                 //   seconds = snoop->rx_ctrl.timestamp / 1000000u;
                 //   microseconds = snoop->rx_ctrl.timestamp % 1000000u;
                 wpcap->pcap_header.microseconds = snoop->rx_ctrl.timestamp;
-                wpcap->pcap_header.capture_length = keepLength;
-                wpcap->pcap_header.packet_length = length;
+                // Original:
+                // wpcap->pcap_header.capture_length = keepLength;
+                // wpcap->pcap_header.packet_length = length;
+                //
+                // PCAP lengths must include the Radiotap header because it is now
+                // part of the captured packet data presented to decoders.
+                wpcap->pcap_header.capture_length = pcapPayloadLength;
+                wpcap->pcap_header.packet_length = RADIOTAP_BASIC_LENGTH + dot11PacketLength;
 
                 // Queue Wireshark/pcap ready packet
                 // Allow brief blocking - WIFIPCAP_HP_PROCESS_PACKET_TIMEOUT_MS
@@ -1005,7 +1167,10 @@ esp_err_t serial_pcap_start(SERIAL_INF* pcapSerial, bool init_custom_filter) {
         CONFIG_WIFIPCAP_TASK_STACK_SIZE, // uint32_t, Stack size in bytes (4 byte increments)
         session,                         // void *, Task input parameter
         CONFIG_WIFIPCAP_TASK_PRIORITY,   // 2 - UBaseType_t , Priority of the task
-        (void**)&session->task);         // TaskHandle_t *, Task handle
+        // session->task is already a TaskHandle_t, so pass its address directly.
+        // The old void** cast hid a type mismatch caused by making the handle volatile.
+        // (void**)&session->task);         // TaskHandle_t *, Task handle
+        &session->task);                 // TaskHandle_t *, Task handle
 #else
     // Linux appears to drop key-strokes when the USB CDC is busy with
     // Wireshark.
@@ -1019,7 +1184,10 @@ esp_err_t serial_pcap_start(SERIAL_INF* pcapSerial, bool init_custom_filter) {
         CONFIG_WIFIPCAP_TASK_STACK_SIZE, // uint32_t, Stack size in bytes (4 byte increments)
         session,                         // void *, Task input parameter
         CONFIG_WIFIPCAP_TASK_PRIORITY,   // 2 - UBaseType_t , Priority of the task
-        (void**)&session->task,          // TaskHandle_t *, Task handle
+        // Same as the unpinned task path: session->task is a TaskHandle_t, so
+        // pass &session->task directly instead of casting through void**.
+        // (void**)&session->task,          // TaskHandle_t *, Task handle
+        &session->task,                  // TaskHandle_t *, Task handle
         // PRO_CPU_NUM);                   // BaseType_t, Core where the task should run
         APP_CPU_NUM);                    // BaseType_t, Core where the task should run
 #endif

--- a/SerialPcap.h
+++ b/SerialPcap.h
@@ -114,7 +114,13 @@ typedef enum {
     PCAP_LINK_TYPE_BSD_SLIP = 102,     // BSD/OS SLIP
     PCAP_LINK_TYPE_BSD_PPP = 103,      // BSD/OS PPP
     PCAP_LINK_TYPE_CISCO_HDLC = 104,   // Cisco HDLC
-    PCAP_LINK_TYPE_802_11 = 105,       // 802.11
+    // Original:
+    // PCAP_LINK_TYPE_802_11 = 105,       // 802.11
+    // PCAP_LINK_TYPE_BSD_LOOPBACK = 108, // OpenBSD loopback devices(with AF_value in network byte order)
+    PCAP_LINK_TYPE_802_11 = 105,       // 802.11 without radio metadata
+    // Radiotap uses a distinct link type because each packet starts with a
+    // Radiotap metadata header before the 802.11 frame.
+    PCAP_LINK_TYPE_IEEE802_11_RADIOTAP = 127, // 802.11 plus Radiotap metadata
     PCAP_LINK_TYPE_BSD_LOOPBACK = 108, // OpenBSD loopback devices(with AF_value in network byte order)
     PCAP_LINK_TYPE_LOCAL_TALK = 114    // LocalTalk
 } pcap_link_type_t;

--- a/extras/esp32shark.py
+++ b/extras/esp32shark.py
@@ -139,6 +139,7 @@ def parseArgs():
     parser.add_argument('--port', '-p', required=False, default=None, help=f'Full device path for USB CDC device connected to {esp32_name}.')
     parser.add_argument('--zc', dest='channel', type=int, choices=range(1, 15), required=False, default=None, help=argparse.SUPPRESS)   # debug
     parser.add_argument('--testing', '--test', '-t', action='store_true', default=None, help="Test run - It does everything but start Wireshark.")
+    parser.add_argument('--gui', action='store_true', default=False, help='Start a small Tkinter control window instead of launching capture immediately.')
 
 
     group2 = parser.add_mutually_exclusive_group(required=False)
@@ -314,6 +315,13 @@ def pickPort():
 def connectESP32(port, channel, filter, unicast, multicast, time_sync):
     global bpsRate
 
+    def serialLineText(line):
+        """
+        Serial diagnostics can contain arbitrary bytes before the PCAP stream
+        starts; keep the handshake log printable without hiding bad bytes.
+        """
+        return line.rstrip(b'\r\n').decode(errors='backslashreplace')
+
     retry = 3
     canBreak = False
     while not canBreak:
@@ -351,7 +359,10 @@ def connectESP32(port, channel, filter, unicast, multicast, time_sync):
             print("[!] Serial port connection closed/failed while reading port!")
             return None
 
-        print(f'[>] ESP32 -> "{line.decode()[:-1]}"')
+        # Old decode() could fail on non-UTF-8 serial noise; serialLineText()
+        # strips line endings and escapes undecodable bytes for safe logging.
+        # print(f'[>] ESP32 -> "{line.decode()[:-1]}"')
+        print(f'[>] ESP32 -> "{serialLineText(line)}"')
         if b"<<SerialPcap>>" in line:
             print("[+] Uploading options ...")
             break
@@ -368,6 +379,10 @@ def connectESP32(port, channel, filter, unicast, multicast, time_sync):
     if filter[1] != None:                   # custome filter
         val = 0x0FFFF & (filter[1] >> 16)   #   only uses the upper 16 bits.
         str += f'S{val}'
+    elif filter[0] != None:
+        # Firmware preserves custom filter state unless an S command is sent.
+        # Clear it when this run only requests SDK-level filtering.
+        str += 'S0'
 
     if unicast:
         str += f'U{unicast[0]}u{unicast[1]}'
@@ -399,22 +414,55 @@ def connectESP32(port, channel, filter, unicast, multicast, time_sync):
             print("[!] Serial port connection closed/failed while reading port!")
             return None
 
-        print(f'[>] ESP32 -> "{line.decode()[:-1]}"')
+        # print(f'[>] ESP32 -> "{line.decode()[:-1]}"')
+        print(f'[>] ESP32 -> "{serialLineText(line)}"')
         if b"<<PASSTHROUGH>>" in line:
             print("[+] Upload Complete ...")
             break
 
     print("[+] Stream started ...")
+    # Use a short read timeout so the relay loop can notice Wireshark exit and
+    # return to the cleanup path that sends EOT back to the ESP32.
+    ser.timeout = 0.05
     return ser
 
 
 def runWireshark(ser):
+    """
+        # Old path gave Wireshark the serial port directly, leaving Python mostly
+        # waiting in communicate(). Keep Python in the relay loop so it can detect
+        # Wireshark exit and send EOT to the ESP32 during cleanup.
+
+        print("[+] Starting Wireshark ...")
+        proc=subprocess.Popen([ wireshark_path, '-k', '-i', '-' ], stdin=ser)
+        proc.communicate()
+        # cmd='wireshark -k -i -'
+        # proc=subprocess.Popen(shlex.split(cmd), stdin=ser, start_new_session=True)
+        # proc=subprocess.Popen(shlex.split(cmd), stdin=ser)
+    """
     print("[+] Starting Wireshark ...")
-    proc=subprocess.Popen([ wireshark_path, '-k', '-i', '-' ], stdin=ser)
-    proc.communicate()
-    # cmd='wireshark -k -i -'
-    # proc=subprocess.Popen(shlex.split(cmd), stdin=ser, start_new_session=True)
-    # proc=subprocess.Popen(shlex.split(cmd), stdin=ser)
+    # Keep Python in the middle instead of handing the serial object directly to
+    # Wireshark, so this script can detect process exit and close the ESP32 side.
+    proc=subprocess.Popen([ wireshark_path, '-k', '-i', '-' ], stdin=subprocess.PIPE)
+    try:
+        while ser.is_open and proc.poll() is None:
+            data = ser.read(4096)
+            if not data:
+                continue
+            try:
+                proc.stdin.write(data)
+                proc.stdin.flush()
+            except BrokenPipeError:
+                break
+    except KeyboardInterrupt:
+        pass
+    finally:
+        if proc.stdin:
+            try:
+                proc.stdin.close()
+            except BrokenPipeError:
+                pass
+        proc.wait()
 
 
 def runWiresharkWin32(ser):
@@ -481,11 +529,247 @@ def processAddress(unicast, oui):
     return [ msb, lsb ]
 
 
+def runTkinterGui(args):
+    """
+    Small desktop control surface for esp32shark.py.
+
+    First pass intentionally launches this same script as a child process instead
+    of duplicating the serial/Wireshark relay in Tkinter callbacks. That keeps
+    the proven CLI path as the single source of truth while giving us a place to
+    grow controls.
+
+    Live channel/filter changes while Wireshark stays open will need firmware
+    support for a sideband control command. The current serial protocol
+    re-enters the PCAP handshake and sends a new PCAP file header, which should
+    not be injected into one already-running Wireshark stdin stream.
+    """
+    try:
+        import tkinter as tk
+        from tkinter import ttk
+        from tkinter import messagebox
+    except Exception as ex:
+        print(f"[!] Tkinter is not available: {ex}")
+        return 1
+
+    class Esp32SharkGui:
+        def __init__(self, root):
+            self.root = root
+            self.proc = None
+            self.reader_thread = None
+
+            root.title(f"{esp32_name} coPilot")
+            root.geometry("720x520")
+            root.minsize(620, 460)
+
+            self.port_var = tk.StringVar()
+            self.channel_var = tk.IntVar(value=args.channel if args.channel else 6)
+            self.filter_var = tk.StringVar(value="Session")
+            self.time_sync_var = tk.BooleanVar(value=args.time_sync)
+            self.status_var = tk.StringVar(value="Idle")
+
+            self.build_widgets()
+            self.refresh_ports()
+
+        def build_widgets(self):
+            outer = ttk.Frame(self.root, padding=14)
+            outer.pack(fill=tk.BOTH, expand=True)
+
+            title = ttk.Label(outer, text=f"{esp32_name} coPilot", font=("TkDefaultFont", 18, "bold"))
+            title.pack(anchor=tk.W)
+
+            subtitle = ttk.Label(
+                outer,
+                text="USB/Wireshark launcher with simple capture controls. Apply changes by restarting capture.",
+                foreground="#666666")
+            subtitle.pack(anchor=tk.W, pady=(2, 14))
+
+            controls = ttk.LabelFrame(outer, text="Capture")
+            controls.pack(fill=tk.X)
+
+            ttk.Label(controls, text="Serial port").grid(row=0, column=0, sticky=tk.W, padx=8, pady=8)
+            self.port_box = ttk.Combobox(controls, textvariable=self.port_var, state="readonly", width=34)
+            self.port_box.grid(row=0, column=1, sticky=tk.EW, padx=8, pady=8)
+            ttk.Button(controls, text="Refresh", command=self.refresh_ports).grid(row=0, column=2, padx=8, pady=8)
+
+            ttk.Label(controls, text="Channel").grid(row=1, column=0, sticky=tk.W, padx=8, pady=8)
+            channel_spin = ttk.Spinbox(controls, from_=1, to=max_channel, textvariable=self.channel_var, width=8)
+            channel_spin.grid(row=1, column=1, sticky=tk.W, padx=8, pady=8)
+
+            ttk.Label(controls, text="Filter").grid(row=2, column=0, sticky=tk.W, padx=8, pady=8)
+            self.filter_box = ttk.Combobox(
+                controls,
+                textvariable=self.filter_var,
+                state="readonly",
+                values=("Previous", "Session", "Good", "All", "Mgmt + Data", "Bad FCS"))
+            self.filter_box.grid(row=2, column=1, sticky=tk.EW, padx=8, pady=8)
+
+            ttk.Checkbutton(controls, text="Sync PCAP start time from this computer", variable=self.time_sync_var).grid(
+                row=3, column=0, columnspan=3, sticky=tk.W, padx=8, pady=8)
+
+            controls.columnconfigure(1, weight=1)
+
+            actions = ttk.Frame(outer)
+            actions.pack(fill=tk.X, pady=12)
+            self.start_button = ttk.Button(actions, text="Start Wireshark", command=self.start_capture)
+            self.start_button.pack(side=tk.LEFT)
+            self.stop_button = ttk.Button(actions, text="Stop", command=self.stop_capture, state=tk.DISABLED)
+            self.stop_button.pack(side=tk.LEFT, padx=(8, 0))
+            ttk.Label(actions, textvariable=self.status_var).pack(side=tk.RIGHT)
+
+            note = ttk.Label(
+                outer,
+                text="Changing controls during capture does not affect the running stream yet. Stop and Start to apply.",
+                foreground="#884400")
+            note.pack(anchor=tk.W, pady=(0, 8))
+
+            log_frame = ttk.LabelFrame(outer, text="Log")
+            log_frame.pack(fill=tk.BOTH, expand=True)
+            self.log_text = tk.Text(log_frame, height=14, wrap=tk.WORD)
+            self.log_text.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+            scroll = ttk.Scrollbar(log_frame, orient=tk.VERTICAL, command=self.log_text.yview)
+            scroll.pack(side=tk.RIGHT, fill=tk.Y)
+            self.log_text.configure(yscrollcommand=scroll.set)
+
+            self.root.protocol("WM_DELETE_WINDOW", self.close)
+
+        def log(self, message):
+            self.log_text.insert(tk.END, message.rstrip() + "\n")
+            self.log_text.see(tk.END)
+
+        def refresh_ports(self):
+            ports = sorted(serial.tools.list_ports.comports())
+            labels = [port.device for port in ports]
+            self.port_box["values"] = labels
+
+            if args.port and args.port in labels:
+                self.port_var.set(args.port)
+            elif labels and not self.port_var.get():
+                self.port_var.set(labels[0])
+
+            self.log("Ports: " + (", ".join(labels) if labels else "none found"))
+
+        def filter_args(self):
+            selected = self.filter_var.get()
+            if selected == "Previous":
+                return []
+            if selected == "Session":
+                return ["--filter_session"]
+            if selected == "Good":
+                return ["--filter_good"]
+            if selected == "All":
+                return ["--filter_all"]
+            if selected == "Mgmt + Data":
+                return ["--filter_mask", "mgmt|data"]
+            if selected == "Bad FCS":
+                return ["--filter_mask", "bad"]
+            return []
+
+        def build_command(self):
+            port = self.port_var.get()
+            if not port:
+                messagebox.showwarning("No Port", "Select a serial port first.")
+                return None
+
+            command = [
+                sys.executable,
+                os.path.abspath(__file__),
+                "--port", port,
+                "--channel", str(self.channel_var.get())
+            ]
+
+            command.extend(self.filter_args())
+
+            if not self.time_sync_var.get():
+                command.append("--no_time_sync")
+
+            return command
+
+        def start_capture(self):
+            if self.proc and self.proc.poll() is None:
+                self.log("Capture is already running.")
+                return
+
+            command = self.build_command()
+            if not command:
+                return
+
+            self.log("[GUI] Starting: " + " ".join(shlex.quote(part) for part in command))
+            env = os.environ.copy()
+            env["PYTHONUNBUFFERED"] = "1"
+            self.proc = subprocess.Popen(
+                command,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                bufsize=1,
+                env=env)
+
+            self.status_var.set("Running")
+            self.start_button.configure(state=tk.DISABLED)
+            self.stop_button.configure(state=tk.NORMAL)
+            self.reader_thread = None
+
+            # Tkinter widgets must only be updated on the GUI thread. The reader
+            # thread hands each line back to root.after().
+            import threading
+            self.reader_thread = threading.Thread(target=self.read_child_output, daemon=True)
+            self.reader_thread.start()
+
+        def read_child_output(self):
+            try:
+                for line in self.proc.stdout:
+                    self.root.after(0, self.log, line)
+            except Exception as ex:
+                self.root.after(0, self.log, f"[GUI] Reader stopped: {ex}")
+            finally:
+                self.root.after(0, self.child_finished)
+
+        def child_finished(self):
+            if self.proc and self.proc.poll() is None:
+                return
+
+            self.status_var.set("Idle")
+            self.start_button.configure(state=tk.NORMAL)
+            self.stop_button.configure(state=tk.DISABLED)
+
+        def stop_capture(self):
+            if not self.proc or self.proc.poll() is not None:
+                self.child_finished()
+                return
+
+            self.log("[GUI] Stopping capture ...")
+            try:
+                # SIGINT gives the child script a chance to send EOT to the ESP32
+                # and close the serial port cleanly.
+                self.proc.send_signal(signal.SIGINT)
+                self.root.after(2500, self.force_stop_if_needed)
+            except Exception as ex:
+                self.log(f"[GUI] Stop failed: {ex}")
+
+        def force_stop_if_needed(self):
+            if self.proc and self.proc.poll() is None:
+                self.log("[GUI] Capture did not stop cleanly; terminating child process.")
+                self.proc.terminate()
+
+        def close(self):
+            self.stop_capture()
+            self.root.after(300, self.root.destroy)
+
+    root = tk.Tk()
+    Esp32SharkGui(root)
+    root.mainloop()
+    return 0
+
+
 def main():
     default_encoding = get_encoding()
 
     try:
         args = parseArgs()
+
+        if args.gui:
+            return runTkinterGui(args)
+
         if args.no_addr:
             unicast = [0, 0]
             multicast = None

--- a/extras/esp32shark.py
+++ b/extras/esp32shark.py
@@ -32,6 +32,7 @@ import sys
 import argparse
 import textwrap
 import locale
+from datetime import datetime
 
 import serial
 import io
@@ -61,6 +62,53 @@ docs_url = f"https://github.com/mhightower83/{esp32_name}/wiki"
 # https://en.wikipedia.org/wiki/List_of_WLAN_channels#endnote_B
 # max_channel = 13    # North America - permitted with channels 12 & 13 at low power
 max_channel = 11    # North America - more common range
+
+# Wait for the binary PCAP header after passthrough before opening Wireshark.
+pcap_start_timeout = 3.0
+
+# Known PCAP global-header byte orders let us distinguish capture bytes from
+# ESP32 diagnostic text on a noisy USB CDC transition.
+pcap_magic_prefixes = (
+    b'\xd4\xc3\xb2\xa1',  # little-endian microsecond PCAP
+    b'\xa1\xb2\xc3\xd4',  # big-endian microsecond PCAP
+    b'\x4d\x3c\xb2\xa1',  # little-endian nanosecond PCAP
+    b'\xa1\xb2\x3c\x4d',  # big-endian nanosecond PCAP
+)
+
+
+# Returns the first PCAP header offset in a mixed text/binary buffer.
+def findPcapMagic(data):
+    positions = [data.find(magic) for magic in pcap_magic_prefixes]
+    positions = [position for position in positions if position >= 0]
+    return min(positions) if positions else -1
+
+
+# Tee command-line output to both the terminal and an optional per-run log.
+class TeeStream:
+    def __init__(self, *streams):
+        self.streams = streams
+
+    def write(self, data):
+        for stream in self.streams:
+            stream.write(data)
+            stream.flush()
+
+    def flush(self):
+        for stream in self.streams:
+            stream.flush()
+
+    def isatty(self):
+        return any(getattr(stream, "isatty", lambda: False)() for stream in self.streams)
+
+
+# Create a fresh log for every CLI or GUI run; never append to old captures.
+def openRunLog(kind):
+    log_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "logs")
+    os.makedirs(log_dir, exist_ok=True)
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S-%f")
+    path = os.path.join(log_dir, f"esp32shark-{kind}-{timestamp}.log")
+    return open(path, "w", encoding="utf-8", buffering=1), path
+
 
 # not using - keeping this for now
 # retrieve *system* encoding, not the one used by python internally
@@ -140,6 +188,8 @@ def parseArgs():
     parser.add_argument('--zc', dest='channel', type=int, choices=range(1, 15), required=False, default=None, help=argparse.SUPPRESS)   # debug
     parser.add_argument('--testing', '--test', '-t', action='store_true', default=None, help="Test run - It does everything but start Wireshark.")
     parser.add_argument('--gui', action='store_true', default=False, help='Start a small Tkinter control window instead of launching capture immediately.')
+    # Logging is explicit so --gui remains screen-only unless requested.
+    parser.add_argument('--log', action='store_true', default=False, help='Write this run to a fresh timestamped log file in extras/logs/.')
 
 
     group2 = parser.add_mutually_exclusive_group(required=False)
@@ -322,6 +372,45 @@ def connectESP32(port, channel, filter, unicast, multicast, time_sync):
         """
         return line.rstrip(b'\r\n').decode(errors='backslashreplace')
 
+    # Find the byte after a marker line so trailing binary data can be preserved.
+    def findAfterLine(data, start):
+        cursor = start
+        while cursor < len(data) and data[cursor] != ord('\n'):
+            cursor += 1
+        if cursor < len(data):
+            cursor += 1
+        return cursor
+
+    # Replacement for immediately starting Wireshark after <<PASSTHROUGH>>:
+    # wait until the stream is aligned at the PCAP global header.
+    def waitForPcapStart(buffered=b''):
+        buffer = bytearray(buffered)
+        deadline = time.monotonic() + pcap_start_timeout
+        old_timeout = ser.timeout
+        ser.timeout = 0.05
+        try:
+            while time.monotonic() < deadline:
+                pcap_index = findPcapMagic(buffer)
+                if pcap_index >= 0:
+                    prefix = bytes(buffer[:pcap_index])
+                    if prefix.strip():
+                        # Keep transition noise visible in logs while dropping
+                        # it from the bytes sent to Wireshark.
+                        print(f'[>] ESP32 -> "{serialLineText(prefix)}"')
+                        print("[!] Ignoring non-PCAP bytes before PCAP header.")
+                    return bytes(buffer[pcap_index:])
+
+                chunk = ser.read(4096)
+                if chunk:
+                    buffer.extend(chunk)
+
+            if buffer.strip():
+                print(f'[>] ESP32 -> "{serialLineText(bytes(buffer))}"')
+            print("[!] Timed out waiting for PCAP header after passthrough.")
+            return None
+        finally:
+            ser.timeout = old_timeout
+
     retry = 3
     canBreak = False
     while not canBreak:
@@ -405,6 +494,8 @@ def connectESP32(port, channel, filter, unicast, multicast, time_sync):
     ser.flush()
     print("[<] ESP32 <- {}".format(cmd))
 
+    # Bytes consumed while finding the PCAP header must be replayed to Wireshark.
+    initial_pcap = b''
     while True:
         try:
             line = ser.readline()
@@ -414,20 +505,42 @@ def connectESP32(port, channel, filter, unicast, multicast, time_sync):
             print("[!] Serial port connection closed/failed while reading port!")
             return None
 
+        # Modified from the old unconditional line print: first split the marker
+        # line from any binary tail, then wait for PCAP alignment.
+        if b"<<PASSTHROUGH>>" in line:
+            passthrough_index = line.find(b"<<PASSTHROUGH>>")
+            after_token = passthrough_index + len(b"<<PASSTHROUGH>>")
+            after_line = findAfterLine(line, after_token)
+            print(f'[>] ESP32 -> "{serialLineText(line[:after_line])}"')
+            print("[+] Upload Complete ...")
+            initial_pcap = waitForPcapStart(line[after_line:])
+            if initial_pcap is None:
+                return None
+            break
+
+        # Recovery path for dropped/truncated PASSTHROUGH text: valid PCAP data
+        # is authoritative once the global header appears.
+        pcap_index = findPcapMagic(line)
+        if pcap_index >= 0:
+            text_prefix = line[:pcap_index]
+            if text_prefix.strip():
+                print(f'[>] ESP32 -> "{serialLineText(text_prefix)}"')
+            print("[!] PASSTHROUGH marker was not seen before PCAP data; continuing from PCAP header.")
+            initial_pcap = line[pcap_index:]
+            break
+
         # print(f'[>] ESP32 -> "{line.decode()[:-1]}"')
         print(f'[>] ESP32 -> "{serialLineText(line)}"')
-        if b"<<PASSTHROUGH>>" in line:
-            print("[+] Upload Complete ...")
-            break
 
     print("[+] Stream started ...")
     # Use a short read timeout so the relay loop can notice Wireshark exit and
     # return to the cleanup path that sends EOT back to the ESP32.
     ser.timeout = 0.05
-    return ser
+    # Return the serial object plus any PCAP bytes already consumed by handshake.
+    return ser, initial_pcap
 
 
-def runWireshark(ser):
+def runWireshark(ser, initial_data=b''):
     """
         # Old path gave Wireshark the serial port directly, leaving Python mostly
         # waiting in communicate(). Keep Python in the relay loop so it can detect
@@ -445,6 +558,15 @@ def runWireshark(ser):
     # Wireshark, so this script can detect process exit and close the ESP32 side.
     proc=subprocess.Popen([ wireshark_path, '-k', '-i', '-' ], stdin=subprocess.PIPE)
     try:
+        if initial_data:
+            # Replay PCAP header bytes consumed during handshake before the relay
+            # reads additional serial data.
+            try:
+                proc.stdin.write(initial_data)
+                proc.stdin.flush()
+            except BrokenPipeError:
+                return
+
         while ser.is_open and proc.poll() is None:
             data = ser.read(4096)
             if not data:
@@ -465,7 +587,7 @@ def runWireshark(ser):
         proc.wait()
 
 
-def runWiresharkWin32(ser):
+def runWiresharkWin32(ser, initial_data=b''):
     # Ref. https://wiki.wireshark.org/CaptureSetup/Pipes.md#way-3-python-on-windows
     # Ref. https://stackoverflow.com/a/13319731
     import win32pipe, win32file
@@ -486,6 +608,11 @@ def runWiresharkWin32(ser):
     try:
         win32pipe.ConnectNamedPipe(pipe, None)  # Wait for connection to pipe
         print("[+] Pipe Connected")
+
+        if initial_data:
+            # Keep Windows named-pipe output aligned with the same initial bytes
+            # used by the stdin pipe path.
+            win32file.WriteFile(pipe, initial_data)
 
         while ser.is_open:
             if 0 < ser.in_waiting:
@@ -551,11 +678,27 @@ def runTkinterGui(args):
         print(f"[!] Tkinter is not available: {ex}")
         return 1
 
+    # Start GUI captures in the same filter mode the CLI args requested; when
+    # omitted, default to All for capture/debug visibility.
+    def initialFilterLabel():
+        if args.filter_mask:
+            return "Filter Mask"
+        if args.filter_good:
+            return "Good"
+        if args.filter_session:
+            return "Session"
+        if args.filter_all:
+            return "All"
+        return "All"
+
     class Esp32SharkGui:
         def __init__(self, root):
             self.root = root
             self.proc = None
             self.reader_thread = None
+            # GUI log handles are set per Start only when --log is active.
+            self.log_file = None
+            self.log_path = None
 
             root.title(f"{esp32_name} coPilot")
             root.geometry("720x520")
@@ -563,9 +706,12 @@ def runTkinterGui(args):
 
             self.port_var = tk.StringVar()
             self.channel_var = tk.IntVar(value=args.channel if args.channel else 6)
-            self.filter_var = tk.StringVar(value="Session")
+            # GUI filter controls mirror the CLI mutually exclusive filter group.
+            self.filter_var = tk.StringVar(value=initialFilterLabel())
+            self.filter_mask_var = tk.StringVar(value=args.filter_mask or "mgmt|data")
             self.time_sync_var = tk.BooleanVar(value=args.time_sync)
             self.status_var = tk.StringVar(value="Idle")
+            self.log_path_var = tk.StringVar(value="")
 
             self.build_widgets()
             self.refresh_ports()
@@ -600,13 +746,21 @@ def runTkinterGui(args):
                 controls,
                 textvariable=self.filter_var,
                 state="readonly",
-                values=("Previous", "Session", "Good", "All", "Mgmt + Data", "Bad FCS"))
+                values=("All", "Good", "Session", "Previous", "Filter Mask"))
             self.filter_box.grid(row=2, column=1, sticky=tk.EW, padx=8, pady=8)
+            self.filter_box.bind("<<ComboboxSelected>>", lambda event: self.update_filter_mask_state())
+
+            ttk.Label(controls, text="Filter mask").grid(row=3, column=0, sticky=tk.W, padx=8, pady=8)
+            # The mask field exposes the full --filter_mask grammar instead of
+            # fixed GUI-only presets.
+            self.filter_mask_entry = ttk.Entry(controls, textvariable=self.filter_mask_var)
+            self.filter_mask_entry.grid(row=3, column=1, sticky=tk.EW, padx=8, pady=8)
 
             ttk.Checkbutton(controls, text="Sync PCAP start time from this computer", variable=self.time_sync_var).grid(
-                row=3, column=0, columnspan=3, sticky=tk.W, padx=8, pady=8)
+                row=4, column=0, columnspan=3, sticky=tk.W, padx=8, pady=8)
 
             controls.columnconfigure(1, weight=1)
+            self.update_filter_mask_state()
 
             actions = ttk.Frame(outer)
             actions.pack(fill=tk.X, pady=12)
@@ -622,6 +776,9 @@ def runTkinterGui(args):
                 foreground="#884400")
             note.pack(anchor=tk.W, pady=(0, 8))
 
+            self.log_path_label = ttk.Label(outer, textvariable=self.log_path_var, foreground="#555555")
+            self.log_path_label.pack(anchor=tk.W, pady=(0, 8))
+
             log_frame = ttk.LabelFrame(outer, text="Log")
             log_frame.pack(fill=tk.BOTH, expand=True)
             self.log_text = tk.Text(log_frame, height=14, wrap=tk.WORD)
@@ -633,8 +790,42 @@ def runTkinterGui(args):
             self.root.protocol("WM_DELETE_WINDOW", self.close)
 
         def log(self, message):
-            self.log_text.insert(tk.END, message.rstrip() + "\n")
+            text = message.rstrip()
+            lines = text.splitlines() if text else [""]
+            for line in lines:
+                self.log_text.insert(tk.END, line + "\n")
+                if self.log_file:
+                    # GUI logs include wall-clock stamps because child output can
+                    # interleave with GUI stop/start events.
+                    stamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+                    try:
+                        self.log_file.write(f"{stamp} {line}\n")
+                        self.log_file.flush()
+                    except OSError as ex:
+                        failed_log = self.log_file
+                        self.log_file = None
+                        try:
+                            failed_log.close()
+                        except OSError:
+                            pass
+                        self.log_text.insert(tk.END, f"[GUI] Run log write failed: {ex}\n")
+                        break
             self.log_text.see(tk.END)
+
+        # Per-run GUI logs use the shared fresh-log helper and are opt-in.
+        def open_run_log(self):
+            self.log_file, self.log_path = openRunLog("gui")
+            self.log_path_var.set("Run log: " + self.log_path)
+
+        # Close run logs on normal child exit, failed launch, or window close.
+        def close_run_log(self):
+            if not self.log_file:
+                return
+            try:
+                self.log_file.close()
+            except OSError:
+                pass
+            self.log_file = None
 
         def refresh_ports(self):
             ports = sorted(serial.tools.list_ports.comports())
@@ -650,19 +841,27 @@ def runTkinterGui(args):
 
         def filter_args(self):
             selected = self.filter_var.get()
-            if selected == "Previous":
-                return []
-            if selected == "Session":
-                return ["--filter_session"]
-            if selected == "Good":
-                return ["--filter_good"]
+            # Keep GUI filter choices as direct translations to CLI flags.
             if selected == "All":
                 return ["--filter_all"]
-            if selected == "Mgmt + Data":
-                return ["--filter_mask", "mgmt|data"]
-            if selected == "Bad FCS":
-                return ["--filter_mask", "bad"]
+            if selected == "Good":
+                return ["--filter_good"]
+            if selected == "Session":
+                return ["--filter_session"]
+            if selected == "Previous":
+                return []
+            if selected == "Filter Mask":
+                mask = self.filter_mask_var.get().strip()
+                if not mask:
+                    messagebox.showwarning("No Filter Mask", "Enter a filter mask first.")
+                    return None
+                return ["--filter_mask", mask]
             return []
+
+        # The custom-mask entry is meaningful only for --filter_mask.
+        def update_filter_mask_state(self):
+            state = tk.NORMAL if self.filter_var.get() == "Filter Mask" else tk.DISABLED
+            self.filter_mask_entry.configure(state=state)
 
         def build_command(self):
             port = self.port_var.get()
@@ -677,7 +876,11 @@ def runTkinterGui(args):
                 "--channel", str(self.channel_var.get())
             ]
 
-            command.extend(self.filter_args())
+            filter_args = self.filter_args()
+            if filter_args is None:
+                return None
+            # Build the child command from the same syntax users can run by hand.
+            command.extend(filter_args)
 
             if not self.time_sync_var.get():
                 command.append("--no_time_sync")
@@ -693,16 +896,38 @@ def runTkinterGui(args):
             if not command:
                 return
 
+            self.close_run_log()
+            self.log_text.delete("1.0", tk.END)
+            self.log_path = None
+            self.log_path_var.set("")
+            if args.log:
+                # --gui does not write files by itself; --gui --log enables this.
+                try:
+                    self.open_run_log()
+                    self.log("[GUI] Log file: " + self.log_path)
+                except OSError as ex:
+                    self.log("[GUI] Could not create run log: " + str(ex))
+
             self.log("[GUI] Starting: " + " ".join(shlex.quote(part) for part in command))
             env = os.environ.copy()
             env["PYTHONUNBUFFERED"] = "1"
-            self.proc = subprocess.Popen(
-                command,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-                text=True,
-                bufsize=1,
-                env=env)
+            try:
+                # Launch errors should restore UI state instead of bubbling out of
+                # Tkinter callbacks.
+                self.proc = subprocess.Popen(
+                    command,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                    text=True,
+                    bufsize=1,
+                    env=env)
+            except OSError as ex:
+                self.log(f"[GUI] Start failed: {ex}")
+                self.status_var.set("Idle")
+                self.start_button.configure(state=tk.NORMAL)
+                self.stop_button.configure(state=tk.DISABLED)
+                self.close_run_log()
+                return
 
             self.status_var.set("Running")
             self.start_button.configure(state=tk.DISABLED)
@@ -712,25 +937,35 @@ def runTkinterGui(args):
             # Tkinter widgets must only be updated on the GUI thread. The reader
             # thread hands each line back to root.after().
             import threading
-            self.reader_thread = threading.Thread(target=self.read_child_output, daemon=True)
+            # Pass the specific process so stale callbacks from an old run cannot
+            # affect a newer capture.
+            self.reader_thread = threading.Thread(target=self.read_child_output, args=(self.proc,), daemon=True)
             self.reader_thread.start()
 
-        def read_child_output(self):
+        def read_child_output(self, proc):
             try:
-                for line in self.proc.stdout:
+                for line in proc.stdout:
                     self.root.after(0, self.log, line)
             except Exception as ex:
                 self.root.after(0, self.log, f"[GUI] Reader stopped: {ex}")
             finally:
-                self.root.after(0, self.child_finished)
+                self.root.after(0, self.child_finished, proc)
 
-        def child_finished(self):
+        def child_finished(self, proc=None):
+            if proc is not None and self.proc is not proc:
+                # Ignore completion callbacks from a previous child process.
+                return
             if self.proc and self.proc.poll() is None:
                 return
 
             self.status_var.set("Idle")
             self.start_button.configure(state=tk.NORMAL)
             self.stop_button.configure(state=tk.DISABLED)
+            return_code = self.proc.returncode if self.proc else None
+            if return_code is not None:
+                self.log(f"[GUI] Child exited with status {return_code}")
+            self.close_run_log()
+            self.proc = None
 
         def stop_capture(self):
             if not self.proc or self.proc.poll() is not None:
@@ -741,18 +976,24 @@ def runTkinterGui(args):
             try:
                 # SIGINT gives the child script a chance to send EOT to the ESP32
                 # and close the serial port cleanly.
-                self.proc.send_signal(signal.SIGINT)
-                self.root.after(2500, self.force_stop_if_needed)
+                proc = self.proc
+                proc.send_signal(signal.SIGINT)
+                # Carry proc into the delayed callback to avoid killing the next
+                # run if the user starts again quickly.
+                self.root.after(2500, self.force_stop_if_needed, proc)
             except Exception as ex:
                 self.log(f"[GUI] Stop failed: {ex}")
 
-        def force_stop_if_needed(self):
-            if self.proc and self.proc.poll() is None:
+        def force_stop_if_needed(self, proc):
+            if self.proc is proc and proc.poll() is None:
+                # This replaces the old global timer that could terminate a newer
+                # child process after a previous run was stopped.
                 self.log("[GUI] Capture did not stop cleanly; terminating child process.")
-                self.proc.terminate()
+                proc.terminate()
 
         def close(self):
             self.stop_capture()
+            self.close_run_log()
             self.root.after(300, self.root.destroy)
 
     root = tk.Tk()
@@ -763,12 +1004,40 @@ def runTkinterGui(args):
 
 def main():
     default_encoding = get_encoding()
+    log_file = None
+    original_stdout = sys.stdout
+    original_stderr = sys.stderr
+
+    # Restore stdout/stderr on every exit path so --log does not leak process
+    # state into callers or traceback handling.
+    def closeLog():
+        nonlocal log_file
+        if not log_file:
+            return
+        sys.stdout = original_stdout
+        sys.stderr = original_stderr
+        try:
+            log_file.close()
+        except OSError:
+            pass
+        log_file = None
 
     try:
         args = parseArgs()
 
         if args.gui:
             return runTkinterGui(args)
+
+        if args.log:
+            try:
+                # CLI logging is a tee: keep terminal output while recording the
+                # same run to a fresh file.
+                log_file, log_path = openRunLog("cli")
+                sys.stdout = TeeStream(original_stdout, log_file)
+                sys.stderr = TeeStream(original_stderr, log_file)
+                print(f'[+] log           ="{log_path}"')
+            except OSError as ex:
+                print(f"[!] Could not create log: {ex}")
 
         if args.no_addr:
             unicast = [0, 0]
@@ -783,61 +1052,71 @@ def main():
         filter = processFilter(args.filter_mask, args.filter_good, args.filter_all, args.filter_session)
     except:
         print("[+] Exiting ...")
+        # If argument/filter parsing fails after opening a log, close it here.
+        closeLog()
         return 1
-
-    if args.port:
-        port = args.port
-    else:
-        port = pickPort()
-        if not port:
-            print("[+] Exiting ...")
-            return 1
-
-    print(f'[+] port          ="{port}"')
-    print(f'[+] channel       ="{args.channel}"')
-    if filter[0]:
-        print(f'[+] filter_mask   ="{filter[0]:#08x}"')
-    else:
-        print('[+] filter_mask   ="None"')
-
-    if filter[1]:
-        print(f'[+] custom_filter ="{filter[1]:#08x}"')
-    else:
-        print('[+] custom_filter ="None"')
-
-    if unicast:
-        print(f'[+] unicast       ="{unicast}"')
-    # elif oui:
-    #     print(f'[+] --oui="{oui}"')
-
-    if multicast:
-        print(f'[+] multicast     ="{multicast}"')
-
-    print(f'[+] set time      ="{args.time_sync}"')
-    # sys.stdout.flush()
-
-    ser = connectESP32(port, args.channel, filter, unicast, multicast, args.time_sync)
-    if None == ser:
-        print("[+] Exiting ...")
-        return 1
-
-    if not args.testing:
-        system = platform.system()
-        if "Windows" == system:
-            runWiresharkWin32(ser)
-        else:
-            runWireshark(ser)
 
     try:
-        ser.write( b'\x04' )        # send ^D (EOT)
-        ser.flush()
-        ser.dtr = ser.rts = False
-        ser.close()
-    except:
-        pass
+        if args.port:
+            port = args.port
+        else:
+            port = pickPort()
+            if not port:
+                print("[+] Exiting ...")
+                return 1
 
-    print("[+] Done.")
-    return 0
+        print(f'[+] port          ="{port}"')
+        print(f'[+] channel       ="{args.channel}"')
+        if filter[0]:
+            print(f'[+] filter_mask   ="{filter[0]:#08x}"')
+        else:
+            print('[+] filter_mask   ="None"')
+
+        if filter[1]:
+            print(f'[+] custom_filter ="{filter[1]:#08x}"')
+        else:
+            print('[+] custom_filter ="None"')
+
+        if unicast:
+            print(f'[+] unicast       ="{unicast}"')
+        # elif oui:
+        #     print(f'[+] --oui="{oui}"')
+
+        if multicast:
+            print(f'[+] multicast     ="{multicast}"')
+
+        print(f'[+] set time      ="{args.time_sync}"')
+        # sys.stdout.flush()
+
+        connection = connectESP32(port, args.channel, filter, unicast, multicast, args.time_sync)
+        if None == connection:
+            print("[+] Exiting ...")
+            return 1
+        # connectESP32 may consume the PCAP header while aligning the stream, so
+        # pass those bytes into the Wireshark relay.
+        ser, initial_pcap = connection
+
+        if not args.testing:
+            system = platform.system()
+            if "Windows" == system:
+                runWiresharkWin32(ser, initial_pcap)
+            else:
+                runWireshark(ser, initial_pcap)
+
+        try:
+            ser.write( b'\x04' )        # send ^D (EOT)
+            ser.flush()
+            ser.dtr = ser.rts = False
+            ser.close()
+        except:
+            pass
+
+        print("[+] Done.")
+        return 0
+    finally:
+        # Keep the log open through the full capture, then close it on every
+        # normal or early return from the main run path.
+        closeLog()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Added `Radiotap.h` with packed Radiotap header definitions, present-bit constants, channel helpers, and layout checks for the initial ESP32 RX metadata header.

- Updated serial PCAP output to prepend a basic Radiotap header to each 802.11 frame and advertise the Radiotap link type, allowing Wireshark to display metadata such as channel, rate, RSSI, noise floor, and antenna.

- Added a `--gui` mode to `extras/esp32shark.py` with a small Tkinter control window for choosing the serial port, channel, filter preset, time sync, and starting or stopping the Wireshark capture.

- Updated `SerialPcap.cpp` so USB CDC builds that use `HWCDC` can still provide the global `USBSerial` instance when USB CDC on boot is disabled.

- Added a serial RX abort check during every PCAP write. The firmware now drains incoming serial data while streaming and treats EOT (`^D`, `0x04`) as a host disconnect request, instead of only checking for EOT after a zero-byte write.

- Cleaned up FreeRTOS task handle handling by storing the task handle directly and passing `&session->task` to task creation calls.

- Made `extras/esp32shark.py` print ESP32 handshake lines safely when non-UTF-8 bytes appear in serial output.

- Made the Python helper explicitly clear custom filter state with `S0` when an SDK filter is sent without a custom filter, avoiding stale custom filtering from a previous run.

- Changed non-Windows Wireshark launching so the script reads from serial and writes PCAP bytes to Wireshark stdin through a pipe. This keeps the Python script in control of shutdown, allowing it to send EOT to the ESP32 when Wireshark exits.

- Set a short serial read timeout before streaming to Wireshark so the relay loop can continue polling process state and shut down promptly.